### PR TITLE
corrected html name of terms of use

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -29,7 +29,7 @@ AUTHOR_FEED_RSS = None
 LINKS = (('Simulation and Software Technology', 'http://www.dlr.de/sc'),
          ('Imprint', '%s/pages/imprint.html' % SITEURL),
          ('Privacy', '%s/pages/privacy.html' % SITEURL),
-         ('Terms of use', '%s/pages/terms_of_use.html' % SITEURL),
+         ('Terms of use', '%s/pages/terms-of-use.html' % SITEURL),
          ('Accessibility', '%s/pages/accessibility.html' % SITEURL),)
 
 # Social widget

--- a/publishconf.py
+++ b/publishconf.py
@@ -23,7 +23,7 @@ DELETE_OUTPUT_DIRECTORY = False
 LINKS = (('Simulation and Software Technology', 'http://www.dlr.de/sc'),
          ('Imprint', '%s/pages/imprint.html' % SITEURL),
          ('Privacy', '%s/pages/privacy.html' % SITEURL),
-         ('Terms of use', '%s/pages/terms_of_use.html' % SITEURL),
+         ('Terms of use', '%s/pages/terms-of-use.html' % SITEURL),
          ('Accessibility', '%s/pages/accessibility.html' % SITEURL),)
 
 


### PR DESCRIPTION
The generated html of the terms of use has a different name than the source file. The name in the pelican configuration was therefore wrong.