### PR TITLE
Enable relative URLs for CI

### DIFF
--- a/themes/polar/templates/base.html
+++ b/themes/polar/templates/base.html
@@ -201,7 +201,7 @@
 
 			 {% if LINKS %}
 				{% for name, link in LINKS %}
-                	&nbsp;&sdot;&nbsp;<a href="{{ link }}">{{ name }}</a></li>
+                	&nbsp;&sdot;&nbsp;<a href="{{ SITEURL }}{{ link }}">{{ name }}</a></li>
             	{% endfor %}
             {% endif %}
 


### PR DESCRIPTION
Currently, the URLs to the legal sites do not work locally and also not in the CI artifacts. This should fix that.