### PR TITLE
Revert "Enable relative URLs for CI"

### DIFF
--- a/themes/polar/templates/base.html
+++ b/themes/polar/templates/base.html
@@ -201,7 +201,7 @@
 
 			 {% if LINKS %}
 				{% for name, link in LINKS %}
-                	&nbsp;&sdot;&nbsp;<a href="{{ SITEURL }}{{ link }}">{{ name }}</a></li>
+                	&nbsp;&sdot;&nbsp;<a href="{{ link }}">{{ name }}</a></li>
             	{% endfor %}
             {% endif %}
 


### PR DESCRIPTION
Reverts DLR-SC/tigl-website#29
Apparently, the links now work in the CI, but this breaks the links on the hosted website.